### PR TITLE
Add line for idr-py installation : custom version for embl training

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN /opt/conda/envs/python2/bin/pip install omego && \
     echo /opt/omero/OMERO.server/lib/python > \
     /opt/conda/envs/python2/lib/python2.7/site-packages/omero.pth
 
+# Install version of IDR-PY which is not dependent on geneinfo for entrez ids
+RUN /opt/conda/envs/python2/bin/pip install --upgrade 'git+https://github.com/bramalingam/idr-py@EMBLPredoc2017Notebooks'
+
 # scipy-notebook only includes python3 packages
 RUN conda install --name python2 --quiet --yes \
     bokeh \


### PR DESCRIPTION
Adds the custom version of idr-py installation step which does not rely on gene info for Entrez ids
